### PR TITLE
Enable browser open when vite starts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,10 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  server: {
+    open: true,
+  },
+});


### PR DESCRIPTION
When `yarn dev` is ran, it opens the localhost server in the browser